### PR TITLE
Create /run/sshd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ RUN apt update \
     && apt -y autoremove \
     && apt clean all
 
+RUN mkdir -p /run/sshd
+
 COPY supervisord.conf /etc/supervisord.conf
 
 EXPOSE 22


### PR DESCRIPTION
I have no idea why, but building this on the raspberry pi won't work without this directory existing before sshd is started.